### PR TITLE
[feature/3-getProfileTab] 프로필 조회하기 - 찍힌 게시물들

### DIFF
--- a/pochak/src/main/java/com/apps/pochak/alarm/domain/Alarm.java
+++ b/pochak/src/main/java/com/apps/pochak/alarm/domain/Alarm.java
@@ -40,6 +40,11 @@ public class Alarm extends BaseEntity {
         return alarmId != null ? alarmId.getSentDate() : null;
     }
 
+    /**
+     * 사용 유의! 앞에 Prefix(ALARM#) 붙어있어야 함.
+     *
+     * @param sentDate
+     */
     public void setSentDate(String sentDate) {
         if (alarmId == null) {
             alarmId = new AlarmId();

--- a/pochak/src/main/java/com/apps/pochak/alarm/domain/Alarm.java
+++ b/pochak/src/main/java/com/apps/pochak/alarm/domain/Alarm.java
@@ -40,6 +40,13 @@ public class Alarm extends BaseEntity {
         return alarmId != null ? alarmId.getSentDate() : null;
     }
 
+    public void setSentDate(String sentDate) {
+        if (alarmId == null) {
+            alarmId = new AlarmId();
+        }
+        alarmId.setSentDate(sentDate);
+    }
+
     public void setSentDate(LocalDateTime sentDate) {
         if (alarmId == null) {
             alarmId = new AlarmId();

--- a/pochak/src/main/java/com/apps/pochak/comment/domain/Comment.java
+++ b/pochak/src/main/java/com/apps/pochak/comment/domain/Comment.java
@@ -54,6 +54,13 @@ public class Comment extends BaseEntity {
         return commentId != null ? commentId.getUploadedDate() : null;
     }
 
+    public void setUploadedDate(String uploadedDate) {
+        if (commentId == null) {
+            commentId = new CommentId();
+        }
+        commentId.setUploadedDate(uploadedDate);
+    }
+
     public void setUploadedDate(LocalDateTime uploadedDate) {
         if (commentId == null) {
             commentId = new CommentId();

--- a/pochak/src/main/java/com/apps/pochak/comment/domain/Comment.java
+++ b/pochak/src/main/java/com/apps/pochak/comment/domain/Comment.java
@@ -54,6 +54,10 @@ public class Comment extends BaseEntity {
         return commentId != null ? commentId.getUploadedDate() : null;
     }
 
+    /**
+     * 사용 유의! 앞에 Prefix(COMMENT#) 붙어있어야 함.
+     * @param uploadedDate
+     */
     public void setUploadedDate(String uploadedDate) {
         if (commentId == null) {
             commentId = new CommentId();

--- a/pochak/src/main/java/com/apps/pochak/common/BaseEntity.java
+++ b/pochak/src/main/java/com/apps/pochak/common/BaseEntity.java
@@ -1,6 +1,7 @@
 package com.apps.pochak.common;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBDocument;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTypeConverted;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTypeConvertedEnum;
 import lombok.Getter;
@@ -16,11 +17,11 @@ import static com.apps.pochak.common.DynamoDBConfig.LocalDateTimeConverter;
 @Getter
 @Setter //Setters are used in aws-dynamodb-sdk
 @NoArgsConstructor
+@DynamoDBDocument
 public class BaseEntity {
-    @CreatedDate
     @DynamoDBAttribute
     @DynamoDBTypeConverted(converter = LocalDateTimeConverter.class)
-    private LocalDateTime createdDate;
+    private LocalDateTime createdDate = LocalDateTime.now(); // @CreatedDate가 작동되지 않아 그냥 now() 씀
 
     @LastModifiedDate
     @DynamoDBAttribute

--- a/pochak/src/main/java/com/apps/pochak/common/BaseResponseStatus.java
+++ b/pochak/src/main/java/com/apps/pochak/common/BaseResponseStatus.java
@@ -18,6 +18,7 @@ public enum BaseResponseStatus {
     NULL_COMMENTS(true, 1200, "아직 게시물에 댓글이 등록되지 않았기에, 미리보기 댓글이 제공되지 않습니다."),
 
     // post (1400 ~ 1599)
+    NULL_TAGGED_POST(true, 1400, "아직 태그된 포스트가 없습니다."),
 
     // alarm (1600 ~ 1799)
 

--- a/pochak/src/main/java/com/apps/pochak/common/BaseResponseStatus.java
+++ b/pochak/src/main/java/com/apps/pochak/common/BaseResponseStatus.java
@@ -9,15 +9,17 @@ public enum BaseResponseStatus {
      * 1000: Success
      */
     SUCCESS(true, 1000, "요청에 성공하였습니다."),
-    NULL_COMMENTS(true, 1001, "아직 댓글이 등록되지 않았습니다"),
+    NULL_COMMENTS(true, 1001, "아직 게시물에 댓글이 등록되지 않았습니다"),
+    NULL_FOLLOW_STATUS(true, 1002, "조회한 프로필이 로그인한 유저의 프로필이기 때문에, 팔로우 여부는 제공되지 않습니다."),
 
     /**
      * 2000: Request error
      */
     // user (2000 ~ 2199)
-    NULL_USER_HANDLE(false, 2000, "유저의 handle을 입력해주세요"),
-    INVALID_UPDATE_REQUEST(false, 2001, "프로필은 당사자만 업데이트할 수 있습니다. API 요청을 다시 확인해주세요."),
-    NULL_USER_NAME(false, 2002, "유저 이름을 입력해주세요"),
+    INVALID_LOGIN_INFO(false, 2000, "유저의 로그인 정보가 유효하지 않습니다."),
+    NULL_USER_HANDLE(false, 2001, "유저의 handle을 입력해주세요"),
+    INVALID_UPDATE_REQUEST(false, 2002, "프로필은 당사자만 업데이트할 수 있습니다. API 요청을 다시 확인해주세요."),
+    NULL_USER_NAME(false, 2003, "유저 이름을 입력해주세요"),
 
     // comment (2200 ~ 2399)
 

--- a/pochak/src/main/java/com/apps/pochak/common/BaseResponseStatus.java
+++ b/pochak/src/main/java/com/apps/pochak/common/BaseResponseStatus.java
@@ -9,8 +9,17 @@ public enum BaseResponseStatus {
      * 1000: Success
      */
     SUCCESS(true, 1000, "요청에 성공하였습니다."),
-    NULL_COMMENTS(true, 1001, "아직 게시물에 댓글이 등록되지 않았습니다"),
-    NULL_FOLLOW_STATUS(true, 1002, "조회한 프로필이 로그인한 유저의 프로필이기 때문에, 팔로우 여부는 제공되지 않습니다."),
+
+    // user (1001 ~ 1199)
+    NULL_FOLLOW_STATUS(true, 1001, "조회한 프로필이 로그인한 유저의 프로필이기 때문에, 팔로우 여부는 제공되지 않습니다."),
+
+
+    // comment (1200 ~ 1399)
+    NULL_COMMENTS(true, 1200, "아직 게시물에 댓글이 등록되지 않았기에, 미리보기 댓글이 제공되지 않습니다."),
+
+    // post (1400 ~ 1599)
+
+    // alarm (1600 ~ 1799)
 
     /**
      * 2000: Request error

--- a/pochak/src/main/java/com/apps/pochak/common/DynamoDBConfig.java
+++ b/pochak/src/main/java/com/apps/pochak/common/DynamoDBConfig.java
@@ -14,6 +14,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.socialsignin.spring.data.dynamodb.config.EnableDynamoDBAuditing;
 import org.socialsignin.spring.data.dynamodb.repository.config.EnableDynamoDBRepositories;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -25,8 +30,14 @@ import java.util.TimeZone;
 
 @Slf4j
 @Configuration
+@SpringBootConfiguration
 @EnableDynamoDBAuditing
 @EnableDynamoDBRepositories(basePackages = {"com.apps.pochak"})
+@EnableAutoConfiguration(exclude = {
+        DataSourceTransactionManagerAutoConfiguration.class,
+        DataSourceAutoConfiguration.class,
+        HibernateJpaAutoConfiguration.class
+})
 public class DynamoDBConfig {
     @Value("${aws.accessKey}")
     private String accessKey;

--- a/pochak/src/main/java/com/apps/pochak/post/domain/Post.java
+++ b/pochak/src/main/java/com/apps/pochak/post/domain/Post.java
@@ -3,7 +3,6 @@ package com.apps.pochak.post.domain;
 import com.amazonaws.services.dynamodbv2.datamodeling.*;
 import com.apps.pochak.annotation.CustomGeneratedKey;
 import com.apps.pochak.common.BaseEntity;
-import com.apps.pochak.common.DynamoDBConfig;
 import com.apps.pochak.user.domain.User;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,9 +21,7 @@ public class Post extends BaseEntity {
     @Id
     private PostId postId;
     private String postPK;
-
-    @DynamoDBTypeConverted(converter = DynamoDBConfig.LocalDateTimeConverter.class)
-    private LocalDateTime allowedDate;
+    private String allowedDate;
 
     @DynamoDBAttribute
     @Getter
@@ -87,14 +84,25 @@ public class Post extends BaseEntity {
     }
 
     @DynamoDBRangeKey(attributeName = "SortKey")
-    public LocalDateTime getAllowedDate() {
+    public String getAllowedDate() {
         return postId != null ? postId.getAllowedDate() : null;
+    }
+
+    /**
+     * 사용 유의! 앞에 Prefix(POST#) 붙어있어야 함.
+     * @param allowedDate
+     */
+    public void setAllowedDate(String allowedDate) {
+        if (postId == null) {
+            postId = new PostId();
+        }
+        postId.setAllowedDate(allowedDate);
     }
 
     public void setAllowedDate(LocalDateTime allowedDate) {
         if (postId == null) {
             postId = new PostId();
         }
-        postId.setAllowedDate(allowedDate);
+        postId.setAllowedDate("POST#" + allowedDate);
     }
 }

--- a/pochak/src/main/java/com/apps/pochak/post/domain/PostId.java
+++ b/pochak/src/main/java/com/apps/pochak/post/domain/PostId.java
@@ -14,7 +14,7 @@ public class PostId implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private String postPK;
-    private LocalDateTime allowedDate;
+    private String allowedDate;
 
     @DynamoDBHashKey
     public String getPostPK() {
@@ -26,11 +26,11 @@ public class PostId implements Serializable {
     }
 
     @DynamoDBRangeKey
-    public LocalDateTime getAllowedDate() {
+    public String getAllowedDate() {
         return allowedDate;
     }
 
-    public void setAllowedDate(LocalDateTime date) {
+    public void setAllowedDate(String date) {
         this.allowedDate = date;
     }
 }

--- a/pochak/src/main/java/com/apps/pochak/post/service/PostService.java
+++ b/pochak/src/main/java/com/apps/pochak/post/service/PostService.java
@@ -54,15 +54,12 @@ public class PostService {
             Post post = requestDto.toEntity(postOwner, taggedUsers);
             Post savedPost = postRepository.savePost(post);
 
-            // save tag, publish
+            // save publish
             Publish publish = new Publish(postOwner, savedPost);
             publishRepository.save(publish);
 
-            // Tag는 Post Upload 수락 후 생성하기
-//            for (User taggedUser : taggedUsers) {
-//                Tag tag = new Tag(taggedUser, savedPost);
-//                tagRepository.save(tag);
-//            }
+            // Tag는 Post Upload 수락 후 생성
+            // TODO: 이후 Alarm 생성 필요
 
             return new PostUploadResDto(savedPost);
         } catch (BaseException e) {

--- a/pochak/src/main/java/com/apps/pochak/publish/domain/Publish.java
+++ b/pochak/src/main/java/com/apps/pochak/publish/domain/Publish.java
@@ -58,6 +58,18 @@ public class Publish extends BaseEntity {
         return publishId != null ? publishId.getUploadedDate() : null;
     }
 
+    /**
+     * 사용 유의! 앞에 prefix(PUBLISH#) 붙어있어야 함.
+     *
+     * @param uploadedDate
+     */
+    public void setUploadedDate(String uploadedDate) {
+        if (publishId == null) {
+            publishId = new PublishId();
+        }
+        publishId.setUploadedDate(uploadedDate);
+    }
+
     public void setUploadedDate(LocalDateTime uploadedDate) {
         if (publishId == null) {
             publishId = new PublishId();

--- a/pochak/src/main/java/com/apps/pochak/tag/domain/Tag.java
+++ b/pochak/src/main/java/com/apps/pochak/tag/domain/Tag.java
@@ -39,7 +39,7 @@ public class Tag extends BaseEntity {
     @Builder
     public Tag(User taggedUser, Post post) {
         setUserHandle(taggedUser.getHandle());
-        setAllowedDate(post.getAllowedDate());
+        setAllowedDate("TAG#" + post.getAllowedDate());
         this.postPK = post.getPostPK();
         this.postImg = post.getImgUrl();
     }
@@ -59,6 +59,13 @@ public class Tag extends BaseEntity {
     @DynamoDBRangeKey(attributeName = "SortKey")
     public String getAllowedDate() {
         return tagId != null ? tagId.getAllowedDate() : null;
+    }
+
+    public void setAllowedDate(String allowedDate) {
+        if (tagId == null) {
+            tagId = new TagId();
+        }
+        tagId.setAllowedDate(allowedDate);
     }
 
     public void setAllowedDate(LocalDateTime allowedDate) {

--- a/pochak/src/main/java/com/apps/pochak/tag/domain/Tag.java
+++ b/pochak/src/main/java/com/apps/pochak/tag/domain/Tag.java
@@ -61,6 +61,11 @@ public class Tag extends BaseEntity {
         return tagId != null ? tagId.getAllowedDate() : null;
     }
 
+    /**
+     * 사용 유의! 앞에 prefix(TAG#) 붙어있어야 함.
+     *
+     * @param allowedDate
+     */
     public void setAllowedDate(String allowedDate) {
         if (tagId == null) {
             tagId = new TagId();

--- a/pochak/src/main/java/com/apps/pochak/tag/domain/Tag.java
+++ b/pochak/src/main/java/com/apps/pochak/tag/domain/Tag.java
@@ -39,7 +39,7 @@ public class Tag extends BaseEntity {
     @Builder
     public Tag(User taggedUser, Post post) {
         setUserHandle(taggedUser.getHandle());
-        setAllowedDate("TAG#" + post.getAllowedDate());
+        setAllowedDate("TAG#" + post.getAllowedDate().substring(5)); // POST# prefix 지우고 저장
         this.postPK = post.getPostPK();
         this.postImg = post.getImgUrl();
     }

--- a/pochak/src/main/java/com/apps/pochak/tag/repository/TagRepository.java
+++ b/pochak/src/main/java/com/apps/pochak/tag/repository/TagRepository.java
@@ -1,9 +1,18 @@
 package com.apps.pochak.tag.repository;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.apps.pochak.common.BaseException;
 import com.apps.pochak.tag.domain.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.apps.pochak.common.BaseResponseStatus.NULL_TAGGED_POST;
 
 @Repository
 @RequiredArgsConstructor
@@ -13,5 +22,26 @@ public class TagRepository {
 
     public Tag save(Tag tag) {
         return tagCrudRepository.save(tag);
+    }
+
+    public List<Tag> findTagsByUserHandle(String userHandle) throws BaseException {
+
+        HashMap<String, String> ean = new HashMap<>();
+        ean.put("#PK", "PartitionKey");
+        ean.put("#SK", "SortKey");
+
+        Map<String, AttributeValue> eav = new HashMap<>();
+        eav.put(":val1", new AttributeValue().withS(userHandle));
+        eav.put(":val2", new AttributeValue().withS("TAG#"));
+
+        DynamoDBQueryExpression<Tag> query = new DynamoDBQueryExpression<Tag>()
+                .withKeyConditionExpression("#PK = :val1 and begins_with(#SK, :val2)")
+                .withExpressionAttributeValues(eav)
+                .withExpressionAttributeNames(ean)
+                .withScanIndexForward(false); // desc
+
+        List<Tag> tags = mapper.query(Tag.class, query);
+
+        return tags;
     }
 }

--- a/pochak/src/main/java/com/apps/pochak/user/controller/UserController.java
+++ b/pochak/src/main/java/com/apps/pochak/user/controller/UserController.java
@@ -3,15 +3,9 @@ package com.apps.pochak.user.controller;
 import com.apps.pochak.common.BaseException;
 import com.apps.pochak.common.BaseResponse;
 import com.apps.pochak.user.domain.User;
-import com.apps.pochak.user.dto.UserFollowersResDto;
-import com.apps.pochak.user.dto.UserUpdateRequestDto;
-import com.apps.pochak.user.dto.UserUpdateResDto;
-import com.apps.pochak.user.dto.UserFollowingsResDto;
 import com.apps.pochak.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-
-import static com.apps.pochak.common.BaseResponseStatus.INVALID_UPDATE_REQUEST;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,40 +22,6 @@ public class UserController {
     public BaseResponse<Boolean> checkHandleDuplicate(@PathVariable("handle") String handle) {
         try {
             return new BaseResponse<>(userService.checkHandleDuplicate(handle));
-        } catch (BaseException e) {
-            return new BaseResponse<>(e.getStatus());
-        }
-    }
-
-
-    // TODO: 유저 로그인 로직 추가
-    @GetMapping("/profile/{handle}/follower")
-    public BaseResponse<UserFollowersResDto> findFollowers(@PathVariable("handle") String userHandle) {
-        try {
-            return new BaseResponse<>(userService.getUserFollowers(userHandle));
-        } catch (BaseException e) {
-            return new BaseResponse<>(e.getStatus());
-        }
-    }
-  
-    // TODO: 유저 로그인 로직 추가
-    @GetMapping("/profile/{handle}/following")
-    public BaseResponse<UserFollowingsResDto> findFollowings(@PathVariable("handle") String userHandle) {
-        try {
-            return new BaseResponse<>(userService.getUserFollowings(userHandle));
-        } catch (BaseException e) {
-            return new BaseResponse<>(e.getStatus());
-        }
-    }
-
-    // TODO: loginUserHandle -> 추후 로그인 로직 필요
-    @PutMapping("/profile/{handle}/")
-    public BaseResponse<UserUpdateResDto> updateUser(@PathVariable("handle") String updatedUserHandle,
-                                                     @RequestParam("loginUser") String loginUserHandle,
-                                                     @RequestBody UserUpdateRequestDto requestDto) {
-        try {
-            if (!updatedUserHandle.equals(loginUserHandle)) throw new BaseException(INVALID_UPDATE_REQUEST);
-            return new BaseResponse<>(userService.updateUserProfile(updatedUserHandle, requestDto));
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }

--- a/pochak/src/main/java/com/apps/pochak/user/controller/UserController.java
+++ b/pochak/src/main/java/com/apps/pochak/user/controller/UserController.java
@@ -21,7 +21,6 @@ public class UserController {
     @GetMapping("/{handle}/exists")
     public BaseResponse<Boolean> checkHandleDuplicate(@PathVariable("handle") String handle) {
         try {
-            handle = "USER#" + handle;
             return new BaseResponse<>(userService.checkHandleDuplicate(handle));
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());

--- a/pochak/src/main/java/com/apps/pochak/user/controller/UserController.java
+++ b/pochak/src/main/java/com/apps/pochak/user/controller/UserController.java
@@ -21,6 +21,7 @@ public class UserController {
     @GetMapping("/{handle}/exists")
     public BaseResponse<Boolean> checkHandleDuplicate(@PathVariable("handle") String handle) {
         try {
+            handle = "USER#" + handle;
             return new BaseResponse<>(userService.checkHandleDuplicate(handle));
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());

--- a/pochak/src/main/java/com/apps/pochak/user/controller/UserProfileController.java
+++ b/pochak/src/main/java/com/apps/pochak/user/controller/UserProfileController.java
@@ -7,8 +7,7 @@ import com.apps.pochak.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import static com.apps.pochak.common.BaseResponseStatus.INVALID_UPDATE_REQUEST;
-import static com.apps.pochak.common.BaseResponseStatus.NULL_FOLLOW_STATUS;
+import static com.apps.pochak.common.BaseResponseStatus.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,6 +20,8 @@ public class UserProfileController {
     public BaseResponse<UserProfileResDto> getUserProfile(@PathVariable("handle") String userHandle,
                                                           @RequestParam("loginUser") String loginUserHandle) {
         try {
+            userHandle = "USER#" + userHandle;
+            loginUserHandle = "USER#" + loginUserHandle;
             UserProfileResDto resDto = userService.getUserProfile(userHandle, loginUserHandle);
             if (userHandle.equals(loginUserHandle)) {
                 return new BaseResponse<>(resDto, NULL_FOLLOW_STATUS);

--- a/pochak/src/main/java/com/apps/pochak/user/controller/UserProfileController.java
+++ b/pochak/src/main/java/com/apps/pochak/user/controller/UserProfileController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import static com.apps.pochak.common.BaseResponseStatus.INVALID_UPDATE_REQUEST;
+import static com.apps.pochak.common.BaseResponseStatus.NULL_FOLLOW_STATUS;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,9 +18,14 @@ public class UserProfileController {
 
     // TODO: 전체적으로 유저 로그인 로직 필요
     @GetMapping("/{handle}")
-    public BaseResponse<UserProfileResDto> getUserProfile(@PathVariable("handle") String userHandle) {
+    public BaseResponse<UserProfileResDto> getUserProfile(@PathVariable("handle") String userHandle,
+                                                          @RequestParam("loginUser") String loginUserHandle) {
         try {
-            return new BaseResponse<>(userService.getUserProfile(userHandle));
+            UserProfileResDto resDto = userService.getUserProfile(userHandle, loginUserHandle);
+            if (userHandle.equals(loginUserHandle)) {
+                return new BaseResponse<>(resDto, NULL_FOLLOW_STATUS);
+            }
+            return new BaseResponse<>(resDto);
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }

--- a/pochak/src/main/java/com/apps/pochak/user/controller/UserProfileController.java
+++ b/pochak/src/main/java/com/apps/pochak/user/controller/UserProfileController.java
@@ -21,8 +21,6 @@ public class UserProfileController {
     public BaseResponse<UserProfileResDto> getUserProfile(@PathVariable("handle") String userHandle,
                                                           @RequestParam("loginUser") String loginUserHandle) {
         try {
-            userHandle = "USER#" + userHandle;
-            loginUserHandle = "USER#" + loginUserHandle;
             UserProfileResDto resDto = userService.getUserProfile(userHandle, loginUserHandle);
             if (userHandle.equals(loginUserHandle)) {
                 return new BaseResponse<>(resDto, NULL_FOLLOW_STATUS);

--- a/pochak/src/main/java/com/apps/pochak/user/controller/UserProfileController.java
+++ b/pochak/src/main/java/com/apps/pochak/user/controller/UserProfileController.java
@@ -2,10 +2,7 @@ package com.apps.pochak.user.controller;
 
 import com.apps.pochak.common.BaseException;
 import com.apps.pochak.common.BaseResponse;
-import com.apps.pochak.user.dto.UserFollowersResDto;
-import com.apps.pochak.user.dto.UserFollowingsResDto;
-import com.apps.pochak.user.dto.UserUpdateRequestDto;
-import com.apps.pochak.user.dto.UserUpdateResDto;
+import com.apps.pochak.user.dto.*;
 import com.apps.pochak.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -18,7 +15,16 @@ import static com.apps.pochak.common.BaseResponseStatus.INVALID_UPDATE_REQUEST;
 public class UserProfileController {
     private final UserService userService;
 
-    // TODO: 유저 로그인 로직 추가
+    // TODO: 전체적으로 유저 로그인 로직 필요
+    @GetMapping("/{handle}")
+    public BaseResponse<UserProfileResDto> getUserProfile(@PathVariable("handle") String userHandle) {
+        try {
+            return new BaseResponse<>(userService.getUserProfile(userHandle));
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
     @GetMapping("/{handle}/follower")
     public BaseResponse<UserFollowersResDto> findFollowers(@PathVariable("handle") String userHandle) {
         try {
@@ -28,7 +34,6 @@ public class UserProfileController {
         }
     }
 
-    // TODO: 유저 로그인 로직 추가
     @GetMapping("/{handle}/following")
     public BaseResponse<UserFollowingsResDto> findFollowings(@PathVariable("handle") String userHandle) {
         try {
@@ -38,7 +43,6 @@ public class UserProfileController {
         }
     }
 
-    // TODO: loginUserHandle -> 추후 로그인 로직 필요
     @PutMapping("/{handle}")
     public BaseResponse<UserUpdateResDto> updateUserProfile(@PathVariable("handle") String updatedUserHandle,
                                                             @RequestParam("loginUser") String loginUserHandle,

--- a/pochak/src/main/java/com/apps/pochak/user/controller/UserProfileController.java
+++ b/pochak/src/main/java/com/apps/pochak/user/controller/UserProfileController.java
@@ -7,7 +7,8 @@ import com.apps.pochak.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import static com.apps.pochak.common.BaseResponseStatus.*;
+import static com.apps.pochak.common.BaseResponseStatus.INVALID_UPDATE_REQUEST;
+import static com.apps.pochak.common.BaseResponseStatus.NULL_FOLLOW_STATUS;
 
 @RestController
 @RequiredArgsConstructor

--- a/pochak/src/main/java/com/apps/pochak/user/controller/UserProfileController.java
+++ b/pochak/src/main/java/com/apps/pochak/user/controller/UserProfileController.java
@@ -1,0 +1,53 @@
+package com.apps.pochak.user.controller;
+
+import com.apps.pochak.common.BaseException;
+import com.apps.pochak.common.BaseResponse;
+import com.apps.pochak.user.dto.UserFollowersResDto;
+import com.apps.pochak.user.dto.UserFollowingsResDto;
+import com.apps.pochak.user.dto.UserUpdateRequestDto;
+import com.apps.pochak.user.dto.UserUpdateResDto;
+import com.apps.pochak.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import static com.apps.pochak.common.BaseResponseStatus.INVALID_UPDATE_REQUEST;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/user/profile")
+public class UserProfileController {
+    private final UserService userService;
+
+    // TODO: 유저 로그인 로직 추가
+    @GetMapping("/{handle}/follower")
+    public BaseResponse<UserFollowersResDto> findFollowers(@PathVariable("handle") String userHandle) {
+        try {
+            return new BaseResponse<>(userService.getUserFollowers(userHandle));
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    // TODO: 유저 로그인 로직 추가
+    @GetMapping("/{handle}/following")
+    public BaseResponse<UserFollowingsResDto> findFollowings(@PathVariable("handle") String userHandle) {
+        try {
+            return new BaseResponse<>(userService.getUserFollowings(userHandle));
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    // TODO: loginUserHandle -> 추후 로그인 로직 필요
+    @PutMapping("/{handle}")
+    public BaseResponse<UserUpdateResDto> updateUserProfile(@PathVariable("handle") String updatedUserHandle,
+                                                            @RequestParam("loginUser") String loginUserHandle,
+                                                            @RequestBody UserUpdateRequestDto requestDto) {
+        try {
+            if (!updatedUserHandle.equals(loginUserHandle)) throw new BaseException(INVALID_UPDATE_REQUEST);
+            return new BaseResponse<>(userService.updateUserProfile(updatedUserHandle, requestDto));
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+}

--- a/pochak/src/main/java/com/apps/pochak/user/domain/User.java
+++ b/pochak/src/main/java/com/apps/pochak/user/domain/User.java
@@ -62,7 +62,7 @@ public class User extends BaseEntity {
 
     @Builder
     public User(String handle, String name, String message, String email, String profileImage) {
-        this.setHandle(handle); // PK와 SK는 setter 사용: ID에 저장하기 위해
+        this.setHandle("USER#" + handle); // PK와 SK는 setter 사용: ID에 저장하기 위해
         this.setUserSK(handle);
         this.setName(name);
         this.message = message;
@@ -79,7 +79,7 @@ public class User extends BaseEntity {
         if (userId == null) {
             userId = new UserId();
         }
-        userId.setHandle("USER#" + handle); // prefix : USER#
+        userId.setHandle(handle);
     }
 
     // SK는 PK와 동일한 값으로 저장됨.

--- a/pochak/src/main/java/com/apps/pochak/user/domain/User.java
+++ b/pochak/src/main/java/com/apps/pochak/user/domain/User.java
@@ -72,7 +72,7 @@ public class User extends BaseEntity {
 
     @DynamoDBHashKey(attributeName = "PartitionKey")
     public String getHandle() {
-        return userId != null ? userId.getHandle().substring(5) : null; // prefix (#USER) 삭제한 값으로 반환
+        return userId != null ? userId.getHandle() : null; // prefix (#USER) 삭제한 값으로 반환
     }
 
     public void setHandle(String handle) {
@@ -85,14 +85,14 @@ public class User extends BaseEntity {
     // SK는 PK와 동일한 값으로 저장됨.
     @DynamoDBRangeKey(attributeName = "SortKey")
     public String getUserSK() {
-        return userId != null ? userId.getUserSK().substring(5) : null;
+        return userId != null ? userId.getUserSK() : null;
     }
 
     public void setUserSK(String userSK) {
         if (userId == null) {
             userId = new UserId();
         }
-        userId.setUserSK("USER#" + userSK);
+        userId.setUserSK(userSK);
     }
 
     public void updateUser(String profileImage, String name, String handle, String message) {

--- a/pochak/src/main/java/com/apps/pochak/user/dto/UserProfileResDto.java
+++ b/pochak/src/main/java/com/apps/pochak/user/dto/UserProfileResDto.java
@@ -1,9 +1,13 @@
 package com.apps.pochak.user.dto;
 
+import com.apps.pochak.post.domain.Post;
+import com.apps.pochak.user.domain.User;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Data
 @NoArgsConstructor
@@ -17,12 +21,38 @@ public class UserProfileResDto {
     private int followerCount;
     private int followingCount;
 
-    private List<ProfilePostDto> pochakedPosts;
+    // 남의 프로필 조회할 경우 사용
+    private boolean isFollow;
+
+    private List<ProfilePostDto> taggedPosts;
+
+    @Builder
+    public UserProfileResDto(User user, User loginUser, List<Post> taggedPosts) {
+        this.handle = user.getHandle();
+        this.userProfileImg = user.getProfileImage();
+        this.userName = user.getName();
+        this.message = user.getMessage();
+        this.totalPostNum = user.getTaggedPostPKs().size();
+        this.followerCount = user.getFollowerUserHandles().size();
+        this.followingCount = user.getFollowingUserHandles().size();
+        if (!user.getHandle().equals(loginUser.getHandle())) {
+            // 유저와 로그인한 유저가 다를 때만 팔로우 상태 제공
+            this.isFollow = user.getFollowerUserHandles().contains(loginUser.getHandle());
+        }
+        this.taggedPosts = taggedPosts.stream().map(post -> {
+            return new ProfilePostDto(post);
+        }).collect(Collectors.toList());
+    }
 
     @Data
     @NoArgsConstructor
     public static class ProfilePostDto {
         private String postPK;
         private String postImg;
+
+        public ProfilePostDto(Post post) {
+            this.postPK = post.getPostPK();
+            this.postImg = post.getImgUrl();
+        }
     }
 }

--- a/pochak/src/main/java/com/apps/pochak/user/dto/UserProfileResDto.java
+++ b/pochak/src/main/java/com/apps/pochak/user/dto/UserProfileResDto.java
@@ -1,0 +1,28 @@
+package com.apps.pochak.user.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class UserProfileResDto {
+    private String handle;
+    private String userProfileImg;
+    private String userName;
+    private String message;
+    private int totalPostNum;
+    private int postCount;
+    private int followerCount;
+    private int followingCount;
+
+    private List<ProfilePostDto> pochakedPosts;
+
+    @Data
+    @NoArgsConstructor
+    public static class ProfilePostDto {
+        private String postPK;
+        private String postImg;
+    }
+}

--- a/pochak/src/main/java/com/apps/pochak/user/dto/UserProfileResDto.java
+++ b/pochak/src/main/java/com/apps/pochak/user/dto/UserProfileResDto.java
@@ -1,11 +1,12 @@
 package com.apps.pochak.user.dto;
 
-import com.apps.pochak.post.domain.Post;
+import com.apps.pochak.tag.domain.Tag;
 import com.apps.pochak.user.domain.User;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -22,26 +23,26 @@ public class UserProfileResDto {
     private int followingCount;
 
     // 남의 프로필 조회할 경우 사용
-    private boolean isFollow;
+    private Boolean isFollow;
 
-    private List<ProfilePostDto> taggedPosts;
+    private List<ProfilePostDto> taggedPosts = new ArrayList<>();
 
     @Builder
-    public UserProfileResDto(User user, User loginUser, List<Post> taggedPosts) {
+    public UserProfileResDto(User user, User loginUser, List<Tag> tags) {
         this.handle = user.getHandle();
         this.userProfileImg = user.getProfileImage();
         this.userName = user.getName();
         this.message = user.getMessage();
-        this.totalPostNum = user.getTaggedPostPKs().size();
+        this.totalPostNum = tags.size();
         this.followerCount = user.getFollowerUserHandles().size();
         this.followingCount = user.getFollowingUserHandles().size();
         if (!user.getHandle().equals(loginUser.getHandle())) {
             // 유저와 로그인한 유저가 다를 때만 팔로우 상태 제공
             this.isFollow = user.getFollowerUserHandles().contains(loginUser.getHandle());
         }
-        this.taggedPosts = taggedPosts.stream().map(post -> {
-            return new ProfilePostDto(post);
-        }).collect(Collectors.toList());
+        this.taggedPosts = tags.stream().map(
+                tag -> new ProfilePostDto(tag)
+        ).collect(Collectors.toList());
     }
 
     @Data
@@ -50,9 +51,9 @@ public class UserProfileResDto {
         private String postPK;
         private String postImg;
 
-        public ProfilePostDto(Post post) {
-            this.postPK = post.getPostPK();
-            this.postImg = post.getImgUrl();
+        public ProfilePostDto(Tag tag) {
+            this.postPK = tag.getPostPK();
+            this.postImg = tag.getPostImg();
         }
     }
 }

--- a/pochak/src/main/java/com/apps/pochak/user/service/UserService.java
+++ b/pochak/src/main/java/com/apps/pochak/user/service/UserService.java
@@ -39,6 +39,7 @@ public class UserService {
             }
 
             User user = userRepository.findUserByUserHandle(userHandle);
+            System.out.println(user.getHandle());
 
             // TODO: 이후 로그인 오류 처리 로직 추가
             User loginUser = userRepository.findUserByUserHandle(loginUserHandle);

--- a/pochak/src/main/java/com/apps/pochak/user/service/UserService.java
+++ b/pochak/src/main/java/com/apps/pochak/user/service/UserService.java
@@ -3,9 +3,9 @@ package com.apps.pochak.user.service;
 import com.apps.pochak.common.BaseException;
 import com.apps.pochak.user.domain.User;
 import com.apps.pochak.user.dto.UserFollowersResDto;
+import com.apps.pochak.user.dto.UserFollowingsResDto;
 import com.apps.pochak.user.dto.UserUpdateRequestDto;
 import com.apps.pochak.user.dto.UserUpdateResDto;
-import com.apps.pochak.user.dto.UserFollowingsResDto;
 import com.apps.pochak.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,8 +15,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.apps.pochak.common.BaseResponseStatus.*;
-import static com.apps.pochak.common.BaseResponseStatus.DATABASE_ERROR;
-import static com.apps.pochak.common.BaseResponseStatus.NULL_USER_HANDLE;
 
 
 @Service
@@ -79,7 +77,7 @@ public class UserService {
     @Transactional
     public UserUpdateResDto updateUserProfile(String updatedUserHandle, UserUpdateRequestDto requestDto) throws BaseException {
         try {
-            User userWithUserHandle = userRepository.findUserWithUserHandle(updatedUserHandle);
+            User userWithUserHandle = userRepository.findUserByUserHandle(updatedUserHandle);
 
             // profileImage와 한줄 소개는 null 값 가능하게 설정.
             if (requestDto.getName().isBlank()) {
@@ -110,7 +108,7 @@ public class UserService {
 
     public Boolean checkHandleDuplicate(String handle) throws BaseException {
         try {
-            userRepository.findUserWithUserHandle(handle);
+            userRepository.findUserByUserHandle(handle);
             return true; // 중복됨
         } catch (BaseException e) {
             if (e.getStatus().equals(INVALID_USER_ID)) {

--- a/pochak/src/main/java/com/apps/pochak/user/service/UserService.java
+++ b/pochak/src/main/java/com/apps/pochak/user/service/UserService.java
@@ -2,10 +2,7 @@ package com.apps.pochak.user.service;
 
 import com.apps.pochak.common.BaseException;
 import com.apps.pochak.user.domain.User;
-import com.apps.pochak.user.dto.UserFollowersResDto;
-import com.apps.pochak.user.dto.UserFollowingsResDto;
-import com.apps.pochak.user.dto.UserUpdateRequestDto;
-import com.apps.pochak.user.dto.UserUpdateResDto;
+import com.apps.pochak.user.dto.*;
 import com.apps.pochak.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,6 +23,17 @@ public class UserService {
     @Transactional
     public User saveUser(User user) {
         return userRepository.saveUser(user);
+    }
+
+    public UserProfileResDto getUserProfile(String userHandle) throws BaseException {
+        try {
+            User userByUserHandle = userRepository.findUserByUserHandle(userHandle);
+            return null;
+        } catch (BaseException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BaseException(DATABASE_ERROR);
+        }
     }
 
     public UserFollowersResDto getUserFollowers(String handle) throws BaseException {

--- a/pochak/src/main/java/com/apps/pochak/user/service/UserService.java
+++ b/pochak/src/main/java/com/apps/pochak/user/service/UserService.java
@@ -39,7 +39,6 @@ public class UserService {
             }
 
             User user = userRepository.findUserByUserHandle(userHandle);
-            System.out.println(user.getHandle());
 
             // TODO: 이후 로그인 오류 처리 로직 추가
             User loginUser = userRepository.findUserByUserHandle(loginUserHandle);

--- a/pochak/src/main/java/com/apps/pochak/user/service/UserService.java
+++ b/pochak/src/main/java/com/apps/pochak/user/service/UserService.java
@@ -1,8 +1,9 @@
 package com.apps.pochak.user.service;
 
 import com.apps.pochak.common.BaseException;
-import com.apps.pochak.post.domain.Post;
 import com.apps.pochak.post.repository.PostRepository;
+import com.apps.pochak.tag.domain.Tag;
+import com.apps.pochak.tag.repository.TagRepository;
 import com.apps.pochak.user.domain.User;
 import com.apps.pochak.user.dto.*;
 import com.apps.pochak.user.repository.UserRepository;
@@ -21,6 +22,7 @@ import static com.apps.pochak.common.BaseResponseStatus.*;
 public class UserService {
     private final UserRepository userRepository;
     private final PostRepository postRepository;
+    private final TagRepository tagRepository;
 
     // test
     @Transactional
@@ -35,22 +37,17 @@ public class UserService {
             } else if (loginUserHandle.isBlank()) {
                 throw new BaseException(INVALID_LOGIN_INFO);
             }
+
             User user = userRepository.findUserByUserHandle(userHandle);
+
+            // TODO: 이후 로그인 오류 처리 로직 추가
             User loginUser = userRepository.findUserByUserHandle(loginUserHandle);
 
-            List<Post> taggedPosts = user.getTaggedPostPKs().stream()
-                    .map(postPK -> {
-                        try {
-                            return postRepository.findPostByPostPK(postPK);
-                        } catch (BaseException e) {
-                            throw new RuntimeException(e);
-                        }
-                    }).collect(Collectors.toList());
-
+            List<Tag> tags = tagRepository.findTagsByUserHandle(userHandle);
             return UserProfileResDto.builder()
                     .user(user)
                     .loginUser(loginUser)
-                    .taggedPosts(taggedPosts)
+                    .tags(tags)
                     .build();
         } catch (BaseException e) {
             throw e;


### PR DESCRIPTION
## 📒 개요

프로필 탭 작업하기!

## 📍 Issue 번호

> #3 

## 🛠️ 작업사항

- [x] Profile 탭 보여주는 거 테스트 완료
  - 앞으로의 테스트를 위한 테스트 데이터 저장해 놓았습니다😁 
  - 그 SK로 descending 정렬도 이번 커밋에 있습니닷 참고하기~
  -  ```java
          DynamoDBQueryExpression<Tag> query = new DynamoDBQueryExpression<Tag>()
                .withKeyConditionExpression("#PK = :val1 and begins_with(#SK, :val2)")
                .withExpressionAttributeValues(eav)
                .withExpressionAttributeNames(ean)
                .withScanIndexForward(false); // desc
       ```

- [x] prefix 중복 저장 해결하고, 경고 주석 작성

## 🚨 주의 사항
- SK 값이 거의 String 값이고 + 앞에 Prefix를 붙이는 것 때문에 prefix가 두 번 생성되는 에러가 좀 많이 나요!!!
- Spring Data Dynamodb에서 Setter나 Getter를 많이 쓰는 것 같은데 사용 유의점 setter 위에 주석 달아놨긴 했지만.... **우리 getter와 setter 사용에 정말정말 유의**합시다...
    - prefix 뗐다 붙였다 ..  진짜 엄청나게 헷갈림요
- 참고로 만약 PathVariable에 # 같은 특수기호가 들어간다면 요청할때 encoding 해줘야 한다고 합니다. 저도 몰랐네요ㅎ 구글링 참고~
    - 참고로 우리 많이 쓰이는 #은  %23 입니닷
- 지금 status가 많은 로직에 들어가진 않았는데... 나중에 꼭 생각하기🤯

## 🤔 의문점
- 지금 DB에 테스트 데이터 넣어놨는데 우리 User PK에 굳이 USER# 안붙여도 되지 않을까요..? 어차피 SK가 USER# 로 시작하는거 가져오는데!